### PR TITLE
Implement minimal generator stubs and UI wiring

### DIFF
--- a/src/generator.js
+++ b/src/generator.js
@@ -1,28 +1,59 @@
 import * as THREE from 'https://unpkg.com/three@0.161.0/build/three.module.js';
 
-export function generateDistrict(scene) {
-  // clear old
-  [...scene.children].forEach(o => {
-    if (o.userData.procedural) scene.remove(o);
-  });
+// simple shared state used by the editor UI
+export const state = {
+  version: 1,
+  seed: (Math.random() * 1e9) >>> 0,
+  env: { timeOfDay: 14 },
+  params: {}
+};
 
-  // ground
+// placeholder groups so main.js can attach them to the scene
+export const districtGroup = new THREE.Group();
+export const carsGroup = new THREE.Group();
+
+// very small linear congruential generator (unused but exported for completeness)
+export function rngFor(seed) {
+  let s = seed >>> 0;
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 0xffffffff;
+  };
+}
+
+// basic stubs for UI hooks
+export function setParam(k, v, scene) {
+  state.params[k] = v;
+}
+
+export function regenRain(scene) {
+  // rain system not implemented in this pared-down demo
+}
+
+export function updateSun(scene, tod) {
+  // sun / lighting adjustments omitted
+}
+
+// generate a very small district: a ground plane and two simple boxes
+export function generateDistrict(scene) {
+  districtGroup.clear();
+
   const ground = new THREE.Mesh(
     new THREE.PlaneGeometry(80, 80),
     new THREE.MeshStandardMaterial({ color: 0x222222, roughness: 1 })
   );
   ground.rotation.x = -Math.PI / 2;
   ground.userData.procedural = true;
-  scene.add(ground);
+  districtGroup.add(ground);
 
-  // 2 buildings
   for (let i = 0; i < 2; i++) {
+    const h = Math.random() * 4 + 3;
     const b = new THREE.Mesh(
-      new THREE.BoxGeometry(4, Math.random() * 4 + 3, 4),
+      new THREE.BoxGeometry(4, h, 4),
       new THREE.MeshStandardMaterial({ color: 0x888888, roughness: 0.6 })
     );
-    b.position.set(Math.random() * 20 - 10, b.geometry.parameters.height / 2, Math.random() * 20 - 10);
+    b.position.set(Math.random() * 20 - 10, h / 2, Math.random() * 20 - 10);
     b.userData.procedural = true;
-    scene.add(b);
+    districtGroup.add(b);
   }
 }

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,7 +1,36 @@
-export function initUI(onGenerate) {
-  document.getElementById('btnGenerate').onclick = onGenerate;
-  document.getElementById('btnResetView').onclick = () => {
-    // emit event for main.js to handle camera reset if needed
-    location.reload();
-  };
+export function wireUI({ onGenerate, onReseed, onFrame, onSave, onRestore, onParam }) {
+  const $ = (id) => document.getElementById(id);
+
+  // basic button wiring
+  $('btnGenerate')?.addEventListener('click', onGenerate);
+  $('btnReseed')?.addEventListener('click', onReseed);
+  $('btnFrame')?.addEventListener('click', onFrame);
+  $('btnSave')?.addEventListener('click', onSave);
+
+  // hook up range/select inputs so they forward their values
+  const inputs = document.querySelectorAll('#ui input, #ui select');
+  inputs.forEach((el) => {
+    el.addEventListener('change', (e) => {
+      const target = e.target;
+      onParam?.(target.id, target.value);
+    });
+  });
+
+  // simple drag-and-drop loader for JSON save files
+  window.addEventListener('dragover', (e) => e.preventDefault());
+  window.addEventListener('drop', (e) => {
+    e.preventDefault();
+    const file = e.dataTransfer?.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        const data = JSON.parse(reader.result);
+        onRestore?.(data);
+      } catch (err) {
+        console.error('Invalid save JSON', err);
+      }
+    };
+    reader.readAsText(file);
+  });
 }


### PR DESCRIPTION
## Summary
- Export state, groups, and stub helpers in `generator.js` so the main module can import them
- Add `wireUI` in `ui.js` to connect buttons, inputs, and drag/drop restore to callbacks
- Generate a simple district with a ground plane and two box buildings

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689643cbfd588332800a731b26d2311e