### PR TITLE
fix orbitcontrols module resolution

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,5 @@
 import * as THREE from 'https://unpkg.com/three@0.161.0/build/three.module.js';
-import { OrbitControls } from 'https://unpkg.com/three@0.161.0/examples/jsm/controls/OrbitControls.js';
+import { OrbitControls } from 'https://unpkg.com/three@0.161.0/examples/jsm/controls/OrbitControls.js?module';
 import { generateDistrict, rngFor, state, setParam, regenRain, updateSun, carsGroup, districtGroup } from './generator.js';
 import { wireUI } from './ui.js';
 


### PR DESCRIPTION
## Summary
- Fix OrbitControls import to use unpkg module variant that resolves three dependency

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68964ba19c808332b4f2efcefb4359ff