### PR TITLE
Add CSP meta tag enabling required script evaluation

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <meta http-equiv="Content-Security-Policy" content="script-src 'self' https://unpkg.com 'unsafe-eval';">
   <title>Neo-Anglo-Norman Procedural Editor</title>
   <style>
     html,body{margin:0;height:100%;background:#0c0e12;color:#e6e6e6;font-family:system-ui,-apple-system,Segoe UI,Roboto,Inter,Arial}


### PR DESCRIPTION
## Summary
- allow script evaluation when using Three.js CDN by adding Content Security Policy meta tag permitting 'unsafe-eval'

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68964d07a0608332a09adb029a90aea3